### PR TITLE
Enable bumping semantic version elements.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,10 @@ Rake tasks included:
 
 | task               | description |
 | ------------------ | ----------- |
-| module:bump        | Bump module version to the next minor |
+| module:bump        | Bump module version to the next patch |
+| module:bump:patch  | Bump module version to the next patch |
+| module:bump:minor  | Bump module version to the next minor version |
+| module:bump:major  | Bump module version to the next major version |
 | module:bump_commit | Bump version and git commit |
 | module:clean       | Runs clean again |
 | module:dependency[modulename, version] | Updates the module version of a specific dependency |
@@ -53,7 +56,7 @@ Bump your `Modulefile` or `metadata.json` to the next version
 
 Configure your credentials in `~/.puppetforge.yml`
 
-    --- 
+    ---
     url: https://forgeapi.puppetlabs.com
     username: myuser
     password: mypassword

--- a/features/update_version.feature
+++ b/features/update_version.feature
@@ -111,3 +111,336 @@ Feature: update_version
       "project_page": "https://github.com/puppetlabs/puppetlabs-stdlib",
     """
     And a file named "Modulefile" should not exist
+
+  Scenario: Bumping a module patch version when using Modulefile
+    Given a file named "Rakefile" with:
+    """
+    require "#{File.dirname(__FILE__)}/../../lib/puppet_blacksmith/rake_tasks"
+    """
+    And a file named "Modulefile" with:
+    """
+    name 'maestrodev-test'
+    version '1.0.0'
+
+    author 'maestrodev'
+    license 'Apache License, Version 2.0'
+    project_page 'http://github.com/maestrodev/puppet-blacksmith'
+    source 'http://github.com/maestrodev/puppet-blacksmith'
+    summary 'Testing Puppet module operations'
+    description 'Testing Puppet module operations'
+    """
+    When I run `rake module:bump:patch`
+    Then the exit status should be 0
+    And the file "Modulefile" should contain:
+    """
+    name 'maestrodev-test'
+    version '1.0.1'
+
+    author 'maestrodev'
+    license 'Apache License, Version 2.0'
+    project_page 'http://github.com/maestrodev/puppet-blacksmith'
+    source 'http://github.com/maestrodev/puppet-blacksmith'
+    summary 'Testing Puppet module operations'
+    description 'Testing Puppet module operations'
+    """
+    And a file named "metadata.json" should not exist
+
+
+  Scenario: Bumping a module patch version when using metadata.json
+    Given a file named "Rakefile" with:
+    """
+    require 'puppetlabs_spec_helper/rake_tasks'
+    require "#{File.dirname(__FILE__)}/../../lib/puppet_blacksmith/rake_tasks"
+    """
+    And a file named "metadata.json" with:
+    """
+    {
+      "operatingsystem_support": [
+        {
+          "operatingsystem": "CentOS",
+          "operatingsystemrelease": [
+            "4",
+            "5",
+            "6"
+          ]
+        }
+      ],
+      "requirements": [
+        {
+          "name": "pe",
+          "version_requirement": "3.2.x"
+        },
+        {
+          "name": "puppet",
+          "version_requirement": ">=2.7.20 <4.0.0"
+        }
+      ],
+      "name": "maestrodev-test",
+      "version": "1.0.0",
+      "source": "git://github.com/puppetlabs/puppetlabs-stdlib",
+      "author": "maestrodev",
+      "license": "Apache 2.0",
+      "summary": "Puppet Module Standard Library",
+      "description": "Standard Library for Puppet Modules",
+      "project_page": "https://github.com/puppetlabs/puppetlabs-stdlib",
+      "dependencies": [
+      ]
+    }
+    """
+    When I run `rake module:bump:patch`
+    Then the exit status should be 0
+    And the file "metadata.json" should contain:
+    """
+    {
+      "operatingsystem_support": [
+        {
+          "operatingsystem": "CentOS",
+          "operatingsystemrelease": [
+            "4",
+            "5",
+            "6"
+          ]
+        }
+      ],
+      "requirements": [
+        {
+          "name": "pe",
+          "version_requirement": "3.2.x"
+        },
+        {
+          "name": "puppet",
+          "version_requirement": ">=2.7.20 <4.0.0"
+        }
+      ],
+      "name": "maestrodev-test",
+      "version": "1.0.1",
+      "source": "git://github.com/puppetlabs/puppetlabs-stdlib",
+      "author": "maestrodev",
+      "license": "Apache 2.0",
+      "summary": "Puppet Module Standard Library",
+      "description": "Standard Library for Puppet Modules",
+      "project_page": "https://github.com/puppetlabs/puppetlabs-stdlib",
+    """
+    And a file named "Modulefile" should not exist
+
+  Scenario: Bumping a module minor version when using Modulefile
+    Given a file named "Rakefile" with:
+    """
+    require "#{File.dirname(__FILE__)}/../../lib/puppet_blacksmith/rake_tasks"
+    """
+    And a file named "Modulefile" with:
+    """
+    name 'maestrodev-test'
+    version '1.0.0'
+
+    author 'maestrodev'
+    license 'Apache License, Version 2.0'
+    project_page 'http://github.com/maestrodev/puppet-blacksmith'
+    source 'http://github.com/maestrodev/puppet-blacksmith'
+    summary 'Testing Puppet module operations'
+    description 'Testing Puppet module operations'
+    """
+    When I run `rake module:bump:minor`
+    Then the exit status should be 0
+    And the file "Modulefile" should contain:
+    """
+    name 'maestrodev-test'
+    version '1.1.0'
+
+    author 'maestrodev'
+    license 'Apache License, Version 2.0'
+    project_page 'http://github.com/maestrodev/puppet-blacksmith'
+    source 'http://github.com/maestrodev/puppet-blacksmith'
+    summary 'Testing Puppet module operations'
+    description 'Testing Puppet module operations'
+    """
+    And a file named "metadata.json" should not exist
+
+
+  Scenario: Bumping a module minor version when using metadata.json
+    Given a file named "Rakefile" with:
+    """
+    require 'puppetlabs_spec_helper/rake_tasks'
+    require "#{File.dirname(__FILE__)}/../../lib/puppet_blacksmith/rake_tasks"
+    """
+    And a file named "metadata.json" with:
+    """
+    {
+      "operatingsystem_support": [
+        {
+          "operatingsystem": "CentOS",
+          "operatingsystemrelease": [
+            "4",
+            "5",
+            "6"
+          ]
+        }
+      ],
+      "requirements": [
+        {
+          "name": "pe",
+          "version_requirement": "3.2.x"
+        },
+        {
+          "name": "puppet",
+          "version_requirement": ">=2.7.20 <4.0.0"
+        }
+      ],
+      "name": "maestrodev-test",
+      "version": "1.0.0",
+      "source": "git://github.com/puppetlabs/puppetlabs-stdlib",
+      "author": "maestrodev",
+      "license": "Apache 2.0",
+      "summary": "Puppet Module Standard Library",
+      "description": "Standard Library for Puppet Modules",
+      "project_page": "https://github.com/puppetlabs/puppetlabs-stdlib",
+      "dependencies": [
+      ]
+    }
+    """
+    When I run `rake module:bump:minor`
+    Then the exit status should be 0
+    And the file "metadata.json" should contain:
+    """
+    {
+      "operatingsystem_support": [
+        {
+          "operatingsystem": "CentOS",
+          "operatingsystemrelease": [
+            "4",
+            "5",
+            "6"
+          ]
+        }
+      ],
+      "requirements": [
+        {
+          "name": "pe",
+          "version_requirement": "3.2.x"
+        },
+        {
+          "name": "puppet",
+          "version_requirement": ">=2.7.20 <4.0.0"
+        }
+      ],
+      "name": "maestrodev-test",
+      "version": "1.1.0",
+      "source": "git://github.com/puppetlabs/puppetlabs-stdlib",
+      "author": "maestrodev",
+      "license": "Apache 2.0",
+      "summary": "Puppet Module Standard Library",
+      "description": "Standard Library for Puppet Modules",
+      "project_page": "https://github.com/puppetlabs/puppetlabs-stdlib",
+    """
+    And a file named "Modulefile" should not exist
+
+  Scenario: Bumping a module major version when using Modulefile
+    Given a file named "Rakefile" with:
+    """
+    require "#{File.dirname(__FILE__)}/../../lib/puppet_blacksmith/rake_tasks"
+    """
+    And a file named "Modulefile" with:
+    """
+    name 'maestrodev-test'
+    version '1.0.0'
+
+    author 'maestrodev'
+    license 'Apache License, Version 2.0'
+    project_page 'http://github.com/maestrodev/puppet-blacksmith'
+    source 'http://github.com/maestrodev/puppet-blacksmith'
+    summary 'Testing Puppet module operations'
+    description 'Testing Puppet module operations'
+    """
+    When I run `rake module:bump:major`
+    Then the exit status should be 0
+    And the file "Modulefile" should contain:
+    """
+    name 'maestrodev-test'
+    version '2.0.0'
+
+    author 'maestrodev'
+    license 'Apache License, Version 2.0'
+    project_page 'http://github.com/maestrodev/puppet-blacksmith'
+    source 'http://github.com/maestrodev/puppet-blacksmith'
+    summary 'Testing Puppet module operations'
+    description 'Testing Puppet module operations'
+    """
+    And a file named "metadata.json" should not exist
+
+
+  Scenario: Bumping a module major version when using metadata.json
+    Given a file named "Rakefile" with:
+    """
+    require 'puppetlabs_spec_helper/rake_tasks'
+    require "#{File.dirname(__FILE__)}/../../lib/puppet_blacksmith/rake_tasks"
+    """
+    And a file named "metadata.json" with:
+    """
+    {
+      "operatingsystem_support": [
+        {
+          "operatingsystem": "CentOS",
+          "operatingsystemrelease": [
+            "4",
+            "5",
+            "6"
+          ]
+        }
+      ],
+      "requirements": [
+        {
+          "name": "pe",
+          "version_requirement": "3.2.x"
+        },
+        {
+          "name": "puppet",
+          "version_requirement": ">=2.7.20 <4.0.0"
+        }
+      ],
+      "name": "maestrodev-test",
+      "version": "1.0.0",
+      "source": "git://github.com/puppetlabs/puppetlabs-stdlib",
+      "author": "maestrodev",
+      "license": "Apache 2.0",
+      "summary": "Puppet Module Standard Library",
+      "description": "Standard Library for Puppet Modules",
+      "project_page": "https://github.com/puppetlabs/puppetlabs-stdlib",
+      "dependencies": [
+      ]
+    }
+    """
+    When I run `rake module:bump:major`
+    Then the exit status should be 0
+    And the file "metadata.json" should contain:
+    """
+    {
+      "operatingsystem_support": [
+        {
+          "operatingsystem": "CentOS",
+          "operatingsystemrelease": [
+            "4",
+            "5",
+            "6"
+          ]
+        }
+      ],
+      "requirements": [
+        {
+          "name": "pe",
+          "version_requirement": "3.2.x"
+        },
+        {
+          "name": "puppet",
+          "version_requirement": ">=2.7.20 <4.0.0"
+        }
+      ],
+      "name": "maestrodev-test",
+      "version": "2.0.0",
+      "source": "git://github.com/puppetlabs/puppetlabs-stdlib",
+      "author": "maestrodev",
+      "license": "Apache 2.0",
+      "summary": "Puppet Module Standard Library",
+      "description": "Standard Library for Puppet Modules",
+      "project_page": "https://github.com/puppetlabs/puppetlabs-stdlib",
+    """
+    And a file named "Modulefile" should not exist

--- a/lib/puppet_blacksmith/modulefile.rb
+++ b/lib/puppet_blacksmith/modulefile.rb
@@ -11,6 +11,8 @@
 # require 'puppet/module_tool'
 require 'puppet'
 require 'puppet/module_tool'
+require 'puppet/vendor'
+require 'semantic'
 
 Puppet[:confdir] = "."
 
@@ -51,12 +53,16 @@ module Blacksmith
       metadata['version']
     end
 
-    def bump!
-      new_version = increase_version(version)
+    def bump!(level = :patch)
+      new_version = increase_version(version, level)
       text = File.read(path)
       text = replace_version(text, new_version)
       File.open(path, "w") {|file| file.puts text}
       new_version
+    end
+
+    [:major, :minor, :patch].each do |level|
+      define_method("bump_#{level}!") { bump!(level) }
     end
 
     def bump_dep!(module_name, version)
@@ -75,10 +81,9 @@ module Blacksmith
       end
     end
 
-    def increase_version(version)
-      v = Gem::Version.new("#{version}.0")
-      raise Blacksmith::Error, "Unable to increase prerelease version #{version}" if v.prerelease?
-      v.bump.to_s
+    def increase_version(version, level = :patch)
+      v = Semantic::Version.parse(version)
+      v.next(level).to_s
     end
 
     def replace_dependency_version(text, module_name, version)

--- a/lib/puppet_blacksmith/rake_tasks.rb
+++ b/lib/puppet_blacksmith/rake_tasks.rb
@@ -18,16 +18,38 @@ module Blacksmith
       task_block.call(*[self, args].slice(0, task_block.arity)) if task_block
 
       # clear any (auto-)pre-existing task
-      [:bump, :tag, :bump_commit, :push, :clean, :release, :dependency].each do |t|
+      [
+        :bump,
+        :bump_major,
+        :bump_minor,
+        :bump_patch,
+        :tag,
+        :bump_commit,
+        :push,
+        :clean,
+        :release,
+        :dependency
+      ].each do |t|
         Rake::Task.task_defined?("module:#{t}") && Rake::Task["module:#{t}"].clear
       end
 
       namespace :module do
 
-        desc "Bump module version to the next minor"
+        namespace :bump do
+          [:major, :minor, :patch].each do |level|
+            desc "Bump module version to the next #{level.upcase} version"
+            task level do
+              m = Blacksmith::Modulefile.new
+              v = m.send("bump_#{level}!")
+              puts "Bumping version from #{m.version} to #{v}"
+            end
+          end
+        end
+
+        desc "Bump module version to the next patch"
         task :bump do
           m = Blacksmith::Modulefile.new
-          v = m.bump!
+          v = m.bump_patch!
           puts "Bumping version from #{m.version} to #{v}"
         end
 

--- a/spec/puppet_blacksmith/modulefile_spec.rb
+++ b/spec/puppet_blacksmith/modulefile_spec.rb
@@ -153,9 +153,27 @@ eos
   end
 
   describe 'increase_version' do
-    it { expect(subject.increase_version("1.0")).to eql("1.1") }
     it { expect(subject.increase_version("1.0.0")).to eql("1.0.1") }
     it { expect(subject.increase_version("1.0.1")).to eql("1.0.2") }
+    it { expect { subject.increase_version("1.0") }.to raise_error }
     it { expect { subject.increase_version("1.0.12qwe") }.to raise_error }
+  end
+
+  describe 'bump patch version' do
+    it { expect(subject.increase_version("1.0.0", :patch)).to eql("1.0.1") }
+    it { expect(subject.increase_version("1.1.0", :patch)).to eql("1.1.1") }
+    it { expect(subject.increase_version("1.1.1", :patch)).to eql("1.1.2") }
+  end
+
+  describe 'bump minor version' do
+    it { expect(subject.increase_version("1.0.0", :minor)).to eql("1.1.0") }
+    it { expect(subject.increase_version("1.1.0", :minor)).to eql("1.2.0") }
+    it { expect(subject.increase_version("1.1.1", :minor)).to eql("1.2.0") }
+  end
+
+  describe 'bump major version' do
+    it { expect(subject.increase_version("1.0.0", :major)).to eql("2.0.0") }
+    it { expect(subject.increase_version("1.1.0", :major)).to eql("2.0.0") }
+    it { expect(subject.increase_version("1.1.1", :major)).to eql("2.0.0") }
   end
 end


### PR DESCRIPTION
Retains default behavior of bumping the patch version with module:bump (even though the docs said it bumped the minor version). I think this would technically be a breaking change as it enforces Semantic Versioning wheras we were using Gem::Version previously, which isn't SemVer. I opted to use the vendored implementation of the 'semantic' gem in 'puppet/vendor' but I'm open to changing that.