### PR TITLE
Enable bumping semantic version elements.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,10 @@ Rake tasks included:
 
 | task               | description |
 | ------------------ | ----------- |
-| module:bump        | Bump module version to the next minor |
+| module:bump        | Bump module version to the next patch |
+| module:bump:patch  | Bump module version to the next patch |
+| module:bump:minor  | Bump module version to the next minor version |
+| module:bump:major  | Bump module version to the next major version |
 | module:bump_commit | Bump version and git commit |
 | module:clean       | Runs clean again |
 | module:dependency[modulename, version] | Updates the module version of a specific dependency |
@@ -53,7 +56,7 @@ Bump your `Modulefile` or `metadata.json` to the next version
 
 Configure your credentials in `~/.puppetforge.yml`
 
-    --- 
+    ---
     url: https://forgeapi.puppetlabs.com
     username: myuser
     password: mypassword

--- a/features/update_version.feature
+++ b/features/update_version.feature
@@ -111,3 +111,336 @@ Feature: update_version
       "project_page": "https://github.com/puppetlabs/puppetlabs-stdlib",
     """
     And a file named "Modulefile" should not exist
+
+  Scenario: Bumping a module patch version when using Modulefile
+    Given a file named "Rakefile" with:
+    """
+    require "#{File.dirname(__FILE__)}/../../lib/puppet_blacksmith/rake_tasks"
+    """
+    And a file named "Modulefile" with:
+    """
+    name 'maestrodev-test'
+    version '1.0.0'
+
+    author 'maestrodev'
+    license 'Apache License, Version 2.0'
+    project_page 'http://github.com/maestrodev/puppet-blacksmith'
+    source 'http://github.com/maestrodev/puppet-blacksmith'
+    summary 'Testing Puppet module operations'
+    description 'Testing Puppet module operations'
+    """
+    When I run `rake module:bump:patch`
+    Then the exit status should be 0
+    And the file "Modulefile" should contain:
+    """
+    name 'maestrodev-test'
+    version '1.0.1'
+
+    author 'maestrodev'
+    license 'Apache License, Version 2.0'
+    project_page 'http://github.com/maestrodev/puppet-blacksmith'
+    source 'http://github.com/maestrodev/puppet-blacksmith'
+    summary 'Testing Puppet module operations'
+    description 'Testing Puppet module operations'
+    """
+    And a file named "metadata.json" should not exist
+
+
+  Scenario: Bumping a module patch version when using metadata.json
+    Given a file named "Rakefile" with:
+    """
+    require 'puppetlabs_spec_helper/rake_tasks'
+    require "#{File.dirname(__FILE__)}/../../lib/puppet_blacksmith/rake_tasks"
+    """
+    And a file named "metadata.json" with:
+    """
+    {
+      "operatingsystem_support": [
+        {
+          "operatingsystem": "CentOS",
+          "operatingsystemrelease": [
+            "4",
+            "5",
+            "6"
+          ]
+        }
+      ],
+      "requirements": [
+        {
+          "name": "pe",
+          "version_requirement": "3.2.x"
+        },
+        {
+          "name": "puppet",
+          "version_requirement": ">=2.7.20 <4.0.0"
+        }
+      ],
+      "name": "maestrodev-test",
+      "version": "1.0.0",
+      "source": "git://github.com/puppetlabs/puppetlabs-stdlib",
+      "author": "maestrodev",
+      "license": "Apache 2.0",
+      "summary": "Puppet Module Standard Library",
+      "description": "Standard Library for Puppet Modules",
+      "project_page": "https://github.com/puppetlabs/puppetlabs-stdlib",
+      "dependencies": [
+      ]
+    }
+    """
+    When I run `rake module:bump:patch`
+    Then the exit status should be 0
+    And the file "metadata.json" should contain:
+    """
+    {
+      "operatingsystem_support": [
+        {
+          "operatingsystem": "CentOS",
+          "operatingsystemrelease": [
+            "4",
+            "5",
+            "6"
+          ]
+        }
+      ],
+      "requirements": [
+        {
+          "name": "pe",
+          "version_requirement": "3.2.x"
+        },
+        {
+          "name": "puppet",
+          "version_requirement": ">=2.7.20 <4.0.0"
+        }
+      ],
+      "name": "maestrodev-test",
+      "version": "1.0.1",
+      "source": "git://github.com/puppetlabs/puppetlabs-stdlib",
+      "author": "maestrodev",
+      "license": "Apache 2.0",
+      "summary": "Puppet Module Standard Library",
+      "description": "Standard Library for Puppet Modules",
+      "project_page": "https://github.com/puppetlabs/puppetlabs-stdlib",
+    """
+    And a file named "Modulefile" should not exist
+
+  Scenario: Bumping a module minor version when using Modulefile
+    Given a file named "Rakefile" with:
+    """
+    require "#{File.dirname(__FILE__)}/../../lib/puppet_blacksmith/rake_tasks"
+    """
+    And a file named "Modulefile" with:
+    """
+    name 'maestrodev-test'
+    version '1.0.0'
+
+    author 'maestrodev'
+    license 'Apache License, Version 2.0'
+    project_page 'http://github.com/maestrodev/puppet-blacksmith'
+    source 'http://github.com/maestrodev/puppet-blacksmith'
+    summary 'Testing Puppet module operations'
+    description 'Testing Puppet module operations'
+    """
+    When I run `rake module:bump:minor`
+    Then the exit status should be 0
+    And the file "Modulefile" should contain:
+    """
+    name 'maestrodev-test'
+    version '1.1.0'
+
+    author 'maestrodev'
+    license 'Apache License, Version 2.0'
+    project_page 'http://github.com/maestrodev/puppet-blacksmith'
+    source 'http://github.com/maestrodev/puppet-blacksmith'
+    summary 'Testing Puppet module operations'
+    description 'Testing Puppet module operations'
+    """
+    And a file named "metadata.json" should not exist
+
+
+  Scenario: Bumping a module minor version when using metadata.json
+    Given a file named "Rakefile" with:
+    """
+    require 'puppetlabs_spec_helper/rake_tasks'
+    require "#{File.dirname(__FILE__)}/../../lib/puppet_blacksmith/rake_tasks"
+    """
+    And a file named "metadata.json" with:
+    """
+    {
+      "operatingsystem_support": [
+        {
+          "operatingsystem": "CentOS",
+          "operatingsystemrelease": [
+            "4",
+            "5",
+            "6"
+          ]
+        }
+      ],
+      "requirements": [
+        {
+          "name": "pe",
+          "version_requirement": "3.2.x"
+        },
+        {
+          "name": "puppet",
+          "version_requirement": ">=2.7.20 <4.0.0"
+        }
+      ],
+      "name": "maestrodev-test",
+      "version": "1.0.0",
+      "source": "git://github.com/puppetlabs/puppetlabs-stdlib",
+      "author": "maestrodev",
+      "license": "Apache 2.0",
+      "summary": "Puppet Module Standard Library",
+      "description": "Standard Library for Puppet Modules",
+      "project_page": "https://github.com/puppetlabs/puppetlabs-stdlib",
+      "dependencies": [
+      ]
+    }
+    """
+    When I run `rake module:bump:minor`
+    Then the exit status should be 0
+    And the file "metadata.json" should contain:
+    """
+    {
+      "operatingsystem_support": [
+        {
+          "operatingsystem": "CentOS",
+          "operatingsystemrelease": [
+            "4",
+            "5",
+            "6"
+          ]
+        }
+      ],
+      "requirements": [
+        {
+          "name": "pe",
+          "version_requirement": "3.2.x"
+        },
+        {
+          "name": "puppet",
+          "version_requirement": ">=2.7.20 <4.0.0"
+        }
+      ],
+      "name": "maestrodev-test",
+      "version": "1.1.0",
+      "source": "git://github.com/puppetlabs/puppetlabs-stdlib",
+      "author": "maestrodev",
+      "license": "Apache 2.0",
+      "summary": "Puppet Module Standard Library",
+      "description": "Standard Library for Puppet Modules",
+      "project_page": "https://github.com/puppetlabs/puppetlabs-stdlib",
+    """
+    And a file named "Modulefile" should not exist
+
+  Scenario: Bumping a module major version when using Modulefile
+    Given a file named "Rakefile" with:
+    """
+    require "#{File.dirname(__FILE__)}/../../lib/puppet_blacksmith/rake_tasks"
+    """
+    And a file named "Modulefile" with:
+    """
+    name 'maestrodev-test'
+    version '1.0.0'
+
+    author 'maestrodev'
+    license 'Apache License, Version 2.0'
+    project_page 'http://github.com/maestrodev/puppet-blacksmith'
+    source 'http://github.com/maestrodev/puppet-blacksmith'
+    summary 'Testing Puppet module operations'
+    description 'Testing Puppet module operations'
+    """
+    When I run `rake module:bump:major`
+    Then the exit status should be 0
+    And the file "Modulefile" should contain:
+    """
+    name 'maestrodev-test'
+    version '2.0.0'
+
+    author 'maestrodev'
+    license 'Apache License, Version 2.0'
+    project_page 'http://github.com/maestrodev/puppet-blacksmith'
+    source 'http://github.com/maestrodev/puppet-blacksmith'
+    summary 'Testing Puppet module operations'
+    description 'Testing Puppet module operations'
+    """
+    And a file named "metadata.json" should not exist
+
+
+  Scenario: Bumping a module major version when using metadata.json
+    Given a file named "Rakefile" with:
+    """
+    require 'puppetlabs_spec_helper/rake_tasks'
+    require "#{File.dirname(__FILE__)}/../../lib/puppet_blacksmith/rake_tasks"
+    """
+    And a file named "metadata.json" with:
+    """
+    {
+      "operatingsystem_support": [
+        {
+          "operatingsystem": "CentOS",
+          "operatingsystemrelease": [
+            "4",
+            "5",
+            "6"
+          ]
+        }
+      ],
+      "requirements": [
+        {
+          "name": "pe",
+          "version_requirement": "3.2.x"
+        },
+        {
+          "name": "puppet",
+          "version_requirement": ">=2.7.20 <4.0.0"
+        }
+      ],
+      "name": "maestrodev-test",
+      "version": "1.0.0",
+      "source": "git://github.com/puppetlabs/puppetlabs-stdlib",
+      "author": "maestrodev",
+      "license": "Apache 2.0",
+      "summary": "Puppet Module Standard Library",
+      "description": "Standard Library for Puppet Modules",
+      "project_page": "https://github.com/puppetlabs/puppetlabs-stdlib",
+      "dependencies": [
+      ]
+    }
+    """
+    When I run `rake module:bump:major`
+    Then the exit status should be 0
+    And the file "metadata.json" should contain:
+    """
+    {
+      "operatingsystem_support": [
+        {
+          "operatingsystem": "CentOS",
+          "operatingsystemrelease": [
+            "4",
+            "5",
+            "6"
+          ]
+        }
+      ],
+      "requirements": [
+        {
+          "name": "pe",
+          "version_requirement": "3.2.x"
+        },
+        {
+          "name": "puppet",
+          "version_requirement": ">=2.7.20 <4.0.0"
+        }
+      ],
+      "name": "maestrodev-test",
+      "version": "2.0.0",
+      "source": "git://github.com/puppetlabs/puppetlabs-stdlib",
+      "author": "maestrodev",
+      "license": "Apache 2.0",
+      "summary": "Puppet Module Standard Library",
+      "description": "Standard Library for Puppet Modules",
+      "project_page": "https://github.com/puppetlabs/puppetlabs-stdlib",
+    """
+    And a file named "Modulefile" should not exist

--- a/lib/puppet_blacksmith/rake_tasks.rb
+++ b/lib/puppet_blacksmith/rake_tasks.rb
@@ -18,16 +18,38 @@ module Blacksmith
       task_block.call(*[self, args].slice(0, task_block.arity)) if task_block
 
       # clear any (auto-)pre-existing task
-      [:bump, :tag, :bump_commit, :push, :clean, :release, :dependency].each do |t|
+      [
+        :bump,
+        :bump_major,
+        :bump_minor,
+        :bump_patch,
+        :tag,
+        :bump_commit,
+        :push,
+        :clean,
+        :release,
+        :dependency
+      ].each do |t|
         Rake::Task.task_defined?("module:#{t}") && Rake::Task["module:#{t}"].clear
       end
 
       namespace :module do
 
-        desc "Bump module version to the next minor"
+        namespace :bump do
+          [:major, :minor, :patch].each do |level|
+            desc "Bump module version to the next #{level.upcase} version"
+            task level do
+              m = Blacksmith::Modulefile.new
+              v = m.send("bump_#{level}!")
+              puts "Bumping version from #{m.version} to #{v}"
+            end
+          end
+        end
+
+        desc "Bump module version to the next patch"
         task :bump do
           m = Blacksmith::Modulefile.new
-          v = m.bump!
+          v = m.bump_patch!
           puts "Bumping version from #{m.version} to #{v}"
         end
 

--- a/lib/puppet_blacksmith/version_helper.rb
+++ b/lib/puppet_blacksmith/version_helper.rb
@@ -1,0 +1,170 @@
+# Need to vendor the 'semantic' gem because Puppet hasn't appropriately
+# encapsulated their vendored implementation.
+#
+# For the original implementation see https://github.com/jlindsey/semantic
+#
+module Blacksmith
+  module VersionHelper
+    # See: http://semver.org
+    class Version
+      SemVerRegexp = /\A(\d+\.\d+\.\d+)(-([0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*))?(\+([0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*))?\Z/
+      attr_accessor :major, :minor, :patch, :pre, :build
+
+      def initialize version_str
+        raise ArgumentError.new("#{version_str} is not a valid SemVer Version (http://semver.org)") unless version_str =~ SemVerRegexp
+
+        version, parts = version_str.split '-'
+        if not parts.nil? and parts.include? '+'
+          @pre, @build = parts.split '+'
+        elsif version.include? '+'
+          version, @build = version.split '+'
+        else
+          @pre = parts
+        end
+
+
+        @major, @minor, @patch = version.split('.').map(&:to_i)
+      end
+
+      def to_a
+        [@major, @minor, @patch, @pre, @build]
+      end
+
+      def to_s
+        str = [@major, @minor, @patch].join '.'
+        str << '-' << @pre unless @pre.nil?
+        str << '+' << @build unless @build.nil?
+
+        str
+      end
+
+      def to_h
+        keys = [:major, :minor, :patch, :pre, :build]
+        Hash[keys.zip(self.to_a)]
+      end
+
+      alias to_hash to_h
+      alias to_array to_a
+      alias to_string to_s
+
+      def <=> other_version
+        other_version = Version.new(other_version) if other_version.is_a? String
+
+        v1 = self.dup
+        v2 = other_version.dup
+
+        # The build must be excluded from the comparison, so that e.g. 1.2.3+foo and 1.2.3+bar are semantically equal.
+        # "Build metadata SHOULD be ignored when determining version precedence".
+        # (SemVer 2.0.0-rc.2, paragraph 10 - http://www.semver.org)
+        v1.build = nil
+        v2.build = nil
+
+        compare_recursively(v1.to_a, v2.to_a)
+      end
+
+      def > other_version
+        (self <=> other_version) == 1
+      end
+
+      def < other_version
+        (self <=> other_version) == -1
+      end
+
+      def >= other_version
+        (self <=> other_version) >= 0
+      end
+
+      def <= other_version
+        (self <=> other_version) <= 0
+      end
+
+      def == other_version
+        (self <=> other_version) == 0
+      end
+
+      def satisfies other_version
+        return true if other_version.strip == '*'
+        parts = other_version.split(/(\d(.+)?)/, 2)
+        comparator, other_version_string = parts[0].strip, parts[1].strip
+
+        begin
+          Version.new other_version_string
+          comparator.empty? && comparator = '=='
+          satisfies_comparator? comparator, other_version_string
+        rescue ArgumentError
+          if ['<', '>', '<=', '>='].include?(comparator)
+            satisfies_comparator? comparator, pad_version_string(other_version_string)
+          else
+            tilde_matches? other_version_string
+          end
+        end
+      end
+
+      [:major, :minor, :patch].each do |term|
+        define_method("#{term}!") { increment!(term) }
+      end
+
+      def increment!(term)
+        new_version = clone
+        new_value = send(term) + 1
+
+        new_version.send("#{term}=", new_value)
+        new_version.minor = 0 if term == :major
+        new_version.patch = 0 if term == :major || term == :minor
+        new_version.build = new_version.pre = nil
+
+        new_version
+      end
+
+      private
+
+      def pad_version_string version_string
+        parts = version_string.split('.').reject {|x| x == '*'}
+        while parts.length < 3
+          parts << '0'
+        end
+        parts.join '.'
+      end
+
+      def tilde_matches? other_version_string
+        this_parts = to_a.collect(&:to_s)
+        other_parts = other_version_string.split('.').reject {|x| x == '*'}
+        other_parts == this_parts[0..other_parts.length-1]
+      end
+
+      def satisfies_comparator? comparator, other_version_string
+        if comparator == '~'
+          tilde_matches? other_version_string
+        else
+          self.send comparator, other_version_string
+        end
+      end
+
+      def compare_recursively ary1, ary2
+        # Short-circuit the recursion entirely if they're just equal
+        return 0 if ary1 == ary2
+
+        a = ary1.shift; b = ary2.shift
+
+        # Reached the end of the arrays, equal all the way down
+        return 0 if a.nil? and b.nil?
+
+        # Mismatched types (ie. one has a pre and the other doesn't)
+        if a.nil? and not b.nil?
+          return 1
+        elsif not a.nil? and b.nil?
+          return -1
+        end
+
+        if a < b
+          return -1
+        elsif a > b
+          return 1
+        end
+
+        # Versions are equal thus far, so recurse down to the next part.
+        compare_recursively ary1, ary2
+      end
+    end
+  end
+end

--- a/spec/puppet_blacksmith/modulefile_spec.rb
+++ b/spec/puppet_blacksmith/modulefile_spec.rb
@@ -153,9 +153,27 @@ eos
   end
 
   describe 'increase_version' do
-    it { expect(subject.increase_version("1.0")).to eql("1.1") }
     it { expect(subject.increase_version("1.0.0")).to eql("1.0.1") }
     it { expect(subject.increase_version("1.0.1")).to eql("1.0.2") }
+    it { expect { subject.increase_version("1.0") }.to raise_error }
     it { expect { subject.increase_version("1.0.12qwe") }.to raise_error }
+  end
+
+  describe 'bump patch version' do
+    it { expect(subject.increase_version("1.0.0", :patch)).to eql("1.0.1") }
+    it { expect(subject.increase_version("1.1.0", :patch)).to eql("1.1.1") }
+    it { expect(subject.increase_version("1.1.1", :patch)).to eql("1.1.2") }
+  end
+
+  describe 'bump minor version' do
+    it { expect(subject.increase_version("1.0.0", :minor)).to eql("1.1.0") }
+    it { expect(subject.increase_version("1.1.0", :minor)).to eql("1.2.0") }
+    it { expect(subject.increase_version("1.1.1", :minor)).to eql("1.2.0") }
+  end
+
+  describe 'bump major version' do
+    it { expect(subject.increase_version("1.0.0", :major)).to eql("2.0.0") }
+    it { expect(subject.increase_version("1.1.0", :major)).to eql("2.0.0") }
+    it { expect(subject.increase_version("1.1.1", :major)).to eql("2.0.0") }
   end
 end


### PR DESCRIPTION
This may be controversial, but I'd love a discussion. I think this functionality is valuable, but contrary to what I'd like to believe, I don't speak for everybody.

This retains the original behavior of bumping the patch version with module:bump (even though the docs said it bumped the minor version). I think this would technically be a breaking change as it enforces Semantic Versioning wheras we were using Gem::Version previously, which isn't SemVer.

Because of the way Puppet has decided to vendor the 'Semantic' gem we're unable to use that namespace because it conflicts with the vendored implementation. This PR vendors our own implementation of the 'Semantic' gem in the Blacksmith::VersionHelper namespace. Not sure if this is the best way to do it, but I can't think of a better way. Need to make sure the original author is credited appropriately.