### PR TITLE
Added bump:full rake task

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Rake tasks included:
 | module:bump:patch  | Bump module version to the next patch |
 | module:bump:minor  | Bump module version to the next minor version |
 | module:bump:major  | Bump module version to the next major version |
+| module:bump:full   | Bump module version to the version set in the BLACKSMITH_FULL_VERSION env variable |
 | module:bump_commit | Bump version and git commit |
 | module:clean       | Runs clean again |
 | module:dependency[modulename, version] | Updates the module version of a specific dependency |

--- a/features/update_version.feature
+++ b/features/update_version.feature
@@ -444,3 +444,200 @@ Feature: update_version
       "project_page": "https://github.com/puppetlabs/puppetlabs-stdlib",
     """
     And a file named "Modulefile" should not exist
+
+
+    Scenario: Bumping to exact module version when using metadata.json
+      Given a file named "Rakefile" with:
+      """
+      require 'puppetlabs_spec_helper/rake_tasks'
+      require "#{File.dirname(__FILE__)}/../../lib/puppet_blacksmith/rake_tasks"
+      """
+      And I set the environment variables to:
+        | variable | value |
+        | BLACKSMITH_FULL_VERSION | 2.1.3 |
+      And a file named "metadata.json" with:
+      """
+      {
+        "operatingsystem_support": [
+          {
+            "operatingsystem": "CentOS",
+            "operatingsystemrelease": [
+              "4",
+              "5",
+              "6"
+            ]
+          }
+        ],
+        "requirements": [
+          {
+            "name": "pe",
+            "version_requirement": "3.2.x"
+          },
+          {
+            "name": "puppet",
+            "version_requirement": ">=2.7.20 <4.0.0"
+          }
+        ],
+        "name": "maestrodev-test",
+        "version": "1.0.0",
+        "source": "git://github.com/puppetlabs/puppetlabs-stdlib",
+        "author": "maestrodev",
+        "license": "Apache 2.0",
+        "summary": "Puppet Module Standard Library",
+        "description": "Standard Library for Puppet Modules",
+        "project_page": "https://github.com/puppetlabs/puppetlabs-stdlib",
+        "dependencies": [
+        ]
+      }
+      """
+      When I run `rake module:bump:full`
+      Then the exit status should be 0
+      And the file "metadata.json" should contain:
+      """
+      {
+        "operatingsystem_support": [
+          {
+            "operatingsystem": "CentOS",
+            "operatingsystemrelease": [
+              "4",
+              "5",
+              "6"
+            ]
+          }
+        ],
+        "requirements": [
+          {
+            "name": "pe",
+            "version_requirement": "3.2.x"
+          },
+          {
+            "name": "puppet",
+            "version_requirement": ">=2.7.20 <4.0.0"
+          }
+        ],
+        "name": "maestrodev-test",
+        "version": "2.1.3",
+        "source": "git://github.com/puppetlabs/puppetlabs-stdlib",
+        "author": "maestrodev",
+        "license": "Apache 2.0",
+        "summary": "Puppet Module Standard Library",
+        "description": "Standard Library for Puppet Modules",
+        "project_page": "https://github.com/puppetlabs/puppetlabs-stdlib",
+      """
+      And a file named "Modulefile" should not exist
+
+
+      Scenario: Bumping to exact module version but not setting the environment variable when using metadata.json
+        Given a file named "Rakefile" with:
+        """
+        require 'puppetlabs_spec_helper/rake_tasks'
+        require "#{File.dirname(__FILE__)}/../../lib/puppet_blacksmith/rake_tasks"
+        """
+        And a file named "metadata.json" with:
+        """
+        {
+          "operatingsystem_support": [
+            {
+              "operatingsystem": "CentOS",
+              "operatingsystemrelease": [
+                "4",
+                "5",
+                "6"
+              ]
+            }
+          ],
+          "requirements": [
+            {
+              "name": "pe",
+              "version_requirement": "3.2.x"
+            },
+            {
+              "name": "puppet",
+              "version_requirement": ">=2.7.20 <4.0.0"
+            }
+          ],
+          "name": "maestrodev-test",
+          "version": "1.0.0",
+          "source": "git://github.com/puppetlabs/puppetlabs-stdlib",
+          "author": "maestrodev",
+          "license": "Apache 2.0",
+          "summary": "Puppet Module Standard Library",
+          "description": "Standard Library for Puppet Modules",
+          "project_page": "https://github.com/puppetlabs/puppetlabs-stdlib",
+          "dependencies": [
+          ]
+        }
+        """
+        When I run `rake module:bump:full`
+        Then the exit status should be 1
+        And the output should contain "Setting the full version requires setting the "
+        And the file "metadata.json" should contain:
+        """
+        {
+          "operatingsystem_support": [
+            {
+              "operatingsystem": "CentOS",
+              "operatingsystemrelease": [
+                "4",
+                "5",
+                "6"
+              ]
+            }
+          ],
+          "requirements": [
+            {
+              "name": "pe",
+              "version_requirement": "3.2.x"
+            },
+            {
+              "name": "puppet",
+              "version_requirement": ">=2.7.20 <4.0.0"
+            }
+          ],
+          "name": "maestrodev-test",
+          "version": "1.0.0",
+          "source": "git://github.com/puppetlabs/puppetlabs-stdlib",
+          "author": "maestrodev",
+          "license": "Apache 2.0",
+          "summary": "Puppet Module Standard Library",
+          "description": "Standard Library for Puppet Modules",
+          "project_page": "https://github.com/puppetlabs/puppetlabs-stdlib",
+        """
+        And a file named "Modulefile" should not exist
+
+
+      Scenario: Bumping to exact module version when using Modulefile
+        Given a file named "Rakefile" with:
+        """
+        require "#{File.dirname(__FILE__)}/../../lib/puppet_blacksmith/rake_tasks"
+        """
+        And I set the environment variables to:
+          | variable | value |
+          | BLACKSMITH_FULL_VERSION | 2.1.3 |
+        And a file named "Modulefile" with:
+        """
+        name 'maestrodev-test'
+        version '1.0.0'
+
+        author 'maestrodev'
+        license 'Apache License, Version 2.0'
+        project_page 'http://github.com/maestrodev/puppet-blacksmith'
+        source 'http://github.com/maestrodev/puppet-blacksmith'
+        summary 'Testing Puppet module operations'
+        description 'Testing Puppet module operations'
+        """
+        When I run `rake module:bump:full`
+        Then the exit status should be 0
+        And the file "Modulefile" should contain:
+        """
+        name 'maestrodev-test'
+        version '2.1.3'
+
+        author 'maestrodev'
+        license 'Apache License, Version 2.0'
+        project_page 'http://github.com/maestrodev/puppet-blacksmith'
+        source 'http://github.com/maestrodev/puppet-blacksmith'
+        summary 'Testing Puppet module operations'
+        description 'Testing Puppet module operations'
+        """
+        And a file named "metadata.json" should not exist

--- a/lib/puppet_blacksmith/modulefile.rb
+++ b/lib/puppet_blacksmith/modulefile.rb
@@ -60,7 +60,7 @@ module Blacksmith
       new_version
     end
 
-    [:major, :minor, :patch].each do |level|
+    [:major, :minor, :patch, :full].each do |level|
       define_method("bump_#{level}!") { bump!(level) }
     end
 

--- a/lib/puppet_blacksmith/rake_tasks.rb
+++ b/lib/puppet_blacksmith/rake_tasks.rb
@@ -24,6 +24,7 @@ module Blacksmith
         'bump:major',
         'bump:minor',
         'bump:patch',
+        'bump:full',
         :tag,
         :bump_commit,
         :push,
@@ -37,7 +38,7 @@ module Blacksmith
       namespace :module do
 
         namespace :bump do
-          [:major, :minor, :patch].each do |level|
+          [:major, :minor, :patch, :full].each do |level|
             desc "Bump module version to the next #{level.upcase} version"
             task level do
               m = Blacksmith::Modulefile.new

--- a/lib/puppet_blacksmith/version_helper.rb
+++ b/lib/puppet_blacksmith/version_helper.rb
@@ -104,6 +104,15 @@ module Blacksmith
         define_method("#{term}!") { increment!(term) }
       end
 
+      def full!
+        env_var = "BLACKSMITH_FULL_VERSION"
+        begin
+          ENV.fetch env_var
+        rescue KeyError
+          raise Exception, "Setting the full version requires setting the #{env_var} environment variable to the new version"
+        end
+      end
+
       def increment!(term)
         new_version = clone
         new_value = send(term) + 1


### PR DESCRIPTION
Allows setting the exact version using the BLACKSMITH_FULL_VERSION env var in combination with the bump:full rake task. Useful for example when CI tool manages the version label for the puppet module